### PR TITLE
Python 3.6 deprecation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
-version: 3
+version: 2
 
 workflows:
-  version: 3
+  version: 2
   test:
     jobs:
       - build-python-3.7

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,17 +1,17 @@
-version: 2
+version: 3
 
 workflows:
-  version: 2
+  version: 3
   test:
     jobs:
-      - build-python-3.6
       - build-python-3.7
       - build-python-3.8
+      - build-python-3.9
 
 jobs:
-  build-python-3.6: &template
+  build-python-3.7: &template
     docker:
-      - image: python:3.6
+      - image: python:3.7
     steps:
       - checkout
       - run:
@@ -36,12 +36,11 @@ jobs:
           # Avoid being able to import citylex by relative import.
           # Test code by importing the *installed* citylex in site-packages.
           command: flake8 project/setup.py project/citylex
-  build-python-3.7:
-    <<: *template
-    docker:
-      - image: python:3.7
   build-python-3.8:
     <<: *template
     docker:
       - image: python:3.8
-
+  build-python-3.9:
+    <<: *template
+    docker:
+      - image: python:3.9

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-flake8==3.8.4
+flake8==3.7.8
 openpyxl==3.0.6
 pandas==1.2.2
 protobuf==3.14.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-flake8==3.7.8
+flake8==3.8.4
 openpyxl==3.0.6
 pandas==1.2.2
 protobuf==3.14.0


### PR DESCRIPTION
Migrate off Python 3.6 altogether.