### PR TITLE
Deprecate Python 3.7 support and add 3.11 support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "citylex"
-version = "0.1.11"
+version = "0.1.12"
 description = "Builds a multi-source English lexicon"
 readme = "README.md"
 requires-python = ">= 3.8"
@@ -25,10 +25,10 @@ dependencies = [
     "requests >= 2.25.1",
 ]
 classifiers = [
-    "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
     "Development Status :: 4 - Beta",
     "Environment :: Console",
     "License :: OSI Approved :: Apache Software License",


### PR DESCRIPTION
CircleCI is already set up like this, we just make the classifiers match.