### PR TITLE
Updates classifiers and CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ jobs:
     docker:
       # Use the latest Python 3.x image from CircleCI.
       # See: https://circleci.com/developer/images/image/cimg/python
-      - image: cimg/python:3.11
+      - image: cimg/python:3.12.1
     steps:
       - checkout
       - run:
@@ -66,4 +66,4 @@ workflows:
             - twine
           matrix:
             parameters:
-              python-version: ["3.8", "3.9", "3.10", "3.11"]
+              python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "citylex"
-version = "0.1.14"
+version = "0.1.15"
 description = "Builds a multi-source English lexicon"
 readme = "README.md"
 requires-python = ">= 3.8"
@@ -25,10 +25,11 @@ dependencies = [
     "requests >= 2.25.1",
 ]
 classifiers = [
-    "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Development Status :: 4 - Beta",
     "Environment :: Console",
     "License :: OSI Approved :: Apache Software License",


### PR DESCRIPTION
This makes the effective range of CityLex 3.8-3.12.

The version number is also bumped.

Closes #15.